### PR TITLE
Update get_statements to new default behavior.

### DIFF
--- a/tfta/tfta.py
+++ b/tfta/tfta.py
@@ -1823,7 +1823,8 @@ class TFTA:
         statements = []
         try:
             for stype in stmt_types:
-                stmts = get_statements(subject=subj, object=obj, stmt_type=stype)
+                stmts = get_statements(subject=subj, object=obj,
+                                       stmt_type=stype, simple_response=True)
                 if len(stmts):
                     stmts_filtered = filter_evidence_source(stmts, ['reach'], policy='one')
                     if len(stmts_filtered):

--- a/tfta/tfta.py
+++ b/tfta/tfta.py
@@ -15,7 +15,7 @@ logging.basicConfig(format='%(levelname)s: %(name)s - %(message)s',
 logger = logging.getLogger('TFTA')
 
 if has_config('INDRA_DB_REST_URL') and has_config('INDRA_DB_REST_API_KEY'):
-    from indra.sources.indra_db_rest.client_api import get_statements
+    from indra.sources.indra_db_rest import get_statements
     from indra.tools.assemble_corpus import filter_evidence_source
     CAN_CHECK_STATEMENTS = True
 else:


### PR DESCRIPTION
By default, get_statements now returns a processor object, which has extra capabilities, rather than a simple list of statements. At some point we should convert this piece of code to make use of the processor.

This PR adjusts to the change made in this INDRA PR: https://github.com/sorgerlab/indra/pull/785